### PR TITLE
Keycloak public key fix

### DIFF
--- a/charts/gzac-backend/templates/configmap.yaml
+++ b/charts/gzac-backend/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
   KEYCLOAK_AUTHSERVERURL: {{ .Values.settings.keycloak.authServerURL | quote }}
   KEYCLOAK_RESOURCE: {{ .Values.settings.keycloak.clientID | quote }}
   KEYCLOAK_REALM: {{ .Values.settings.keycloak.realm | quote }}
-  KEYCLOAK_PUBLIC_KEY: {{ .Values.settings.keycloak.publicKey | quote }}
+  VALTIMO_OAUTH_PUBLIC_KEY: {{ .Values.settings.keycloak.publicKey | quote }}
   VALTIMO_APP_HOSTNAME: {{ .Values.settings.gzac.appHostname | quote }}
   VALTIMO_DATABASE: {{ .Values.settings.gzac.databaseType | quote }}
   CAMUNDA_BPM_ADMINUSER_ID: {{ .Values.settings.camunda.adminUserID | quote }}


### PR DESCRIPTION
Changed envvar name from KEYCLOAK_PUBLIC_KEY to VALTIMO_OAUTH_PUBLIC_KEY.
See https://docs.valtimo.nl/using-valtimo/keycloak/configuring-keycloak#keycloak-token-authentication