### PR TITLE
HPA api update to autoscaling/v2

### DIFF
--- a/charts/gzac-backend/gzac-backend/Chart.yaml
+++ b/charts/gzac-backend/gzac-backend/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 12.2.0
 description: A Helm chart for Kubernetes
 name: gzac-backend
 type: application
-version: 3.0.6
+version: 3.0.7
 
 dependencies:
   - name: postgresql

--- a/charts/gzac-backend/gzac-backend/templates/hpa.yaml
+++ b/charts/gzac-backend/gzac-backend/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "gzac-backend.fullname" . }}


### PR DESCRIPTION
Updated api version of horizontal pod autoscaler to autoscaling/v2.
See https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125