### PR TITLE
targetAverageUtilization vervangen door target: type:

### DIFF
--- a/charts/gzac-backend/gzac-backend/templates/hpa.yaml
+++ b/charts/gzac-backend/gzac-backend/templates/hpa.yaml
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Ik kreeg in flux de foutmelding:
`warning: Upgrade "gzac-backend" failed: failed to create resource: HorizontalPodAutoscaler.autoscaling "gzac-backend" is invalid: [spec.metrics[0].resource.target.type: Required value: must specify a metric target type, spec.metrics[0].resource.target.type: Invalid value: "": must be either Utilization, Value, or AverageValue, spec.metrics[0].resource.target.averageUtilization: Required value: must set either a target raw value or a target utilization, spec.metrics[1].resource.target.type: Required value: must specify a metric target type, spec.metrics[1].resource.target.type: Invalid value: "": must be either Utilization, Value, or AverageValue, spec.metrics[1].resource.target.averageUtilization: Required value: must set either a target raw value or a target utilization]`