### PR TITLE
Add PR workflows

### DIFF
--- a/.github/workflows/gzac-backend-pr.yaml
+++ b/.github/workflows/gzac-backend-pr.yaml
@@ -1,0 +1,52 @@
+name: Generate and push README to PR source branch
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "charts/gzac-backend/**"
+
+jobs:
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the PR source branch
+        uses: actions/checkout@v4
+
+      - name: Install helm
+        uses: Azure/setup-helm@v3
+        with:
+          version: 3.9.0
+      - name: Helm Lint
+        run: |
+          cd charts/gzac-frontend/gzac-frontend
+          helm lint
+
+  add-readme-if-missing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the PR source branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update README.md with helm-docs
+        env:
+          HELM_DOCS_VERSION: v1.14.2
+        run: |
+          cd charts/gzac-backend/gzac-backend
+          docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) "jnorwood/helm-docs:${HELM_DOCS_VERSION}"
+
+      - name: Push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --cached --quiet; then
+            echo "README is up-to-date. No changes to commit."
+          else
+            git commit -m "Update README.md automatically via GitHub Actions"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          fi

--- a/.github/workflows/gzac-frontend-pr.yaml
+++ b/.github/workflows/gzac-frontend-pr.yaml
@@ -1,0 +1,51 @@
+name: Generate and push README to PR source branch
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "charts/gzac-frontend/**"
+jobs:
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the PR source branch
+        uses: actions/checkout@v4
+
+      - name: Install helm
+        uses: Azure/setup-helm@v3
+        with:
+          version: 3.9.0
+      - name: Helm Lint
+        run: |
+          cd charts/gzac-frontend/gzac-frontend
+          helm lint
+
+  add-readme-if-missing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the PR source branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update README.md with helm-docs
+        env:
+          HELM_DOCS_VERSION: v1.14.2
+        run: |
+          cd charts/gzac-frontend/gzac-frontend
+          docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) "jnorwood/helm-docs:${HELM_DOCS_VERSION}"
+
+      - name: Push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --cached --quiet; then
+            echo "README is up-to-date. No changes to commit."
+          else
+            git commit -m "Update README.md automatically via GitHub Actions"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          fi


### PR DESCRIPTION
Adds a workflow for the frontend and backend charts.
On PR, the workflow:
- Lints the Chart with `helm lint`. This detects e.g. non-existent values being referenced in the templates.
- Checks if the README.md for the Chart has been updated. If not, it will update it for you by pushing to the PR source branch.