### PR TITLE
Add Operaton cockpit with keycloak

### DIFF
--- a/.github/workflows/operaton-cockpit-pr.yaml
+++ b/.github/workflows/operaton-cockpit-pr.yaml
@@ -1,0 +1,55 @@
+name: Operaton Cockpit Keycloak - run Helm lint, generate and push README to PR source branch
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "charts/operaton-cockpit/**"
+
+jobs:
+  helm-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the PR source branch
+        uses: actions/checkout@v4
+
+      - name: Install helm
+        uses: Azure/setup-helm@v3
+        with:
+          version: 3.9.0
+      - name: Helm Lint
+        run: |
+          cd charts/operaton-cockpit/operaton-cockpit
+          helm lint
+
+  add-readme-if-missing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the PR source branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update README.md with helm-docs
+        env:
+          HELM_DOCS_VERSION: v1.14.2
+        run: |
+          cd charts/operaton-cockpit/operaton-cockpit
+          docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) "jnorwood/helm-docs:${HELM_DOCS_VERSION}"
+
+      - name: Push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd charts/operaton-cockpit/operaton-cockpit
+          git add .
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --cached --quiet; then
+            echo "README is up-to-date. No changes to commit."
+          else
+            git commit -m "Update README.md automatically via GitHub Actions"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          fi

--- a/.github/workflows/operaton-cockpit.yaml
+++ b/.github/workflows/operaton-cockpit.yaml
@@ -1,0 +1,35 @@
+name: Build and Publish Operaton Cockpit Keycloak helmchart
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "charts/operaton-cockpit/**"
+    branches:
+      - main
+
+jobs:
+  build_gzac_backend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: install helm
+        uses: Azure/setup-helm@v3
+        with:
+          version: 3.9.0
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        with:
+          charts_dir: charts/operaton-cockpit
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Valtimo GZAC Helm charts
 
-This repository contains the helm charts for the Valtimo GZAC application and a Keycloak-compatible version of Camunda Cockpit to run alongside it.
+This repository contains the helm charts for the Valtimo GZAC application and a Keycloak-compatible version of Camunda Cockpit and Operaton Cockpit to run alongside it.
 
 For the GZAC backend, please pick the right chart version to ensure the proper configmap/envvars are setup in your cluster.
 
@@ -19,7 +19,8 @@ Find the helm configuration values here:
 
 - [GZAC Backend](/charts/gzac-backend/gzac-backend/README.md)
 - [GZAC Frontend](/charts/gzac-frontend/gzac-frontend/README.md)
-- [Camunda Cockpit](/charts/camunda-cockpit-keycloak/README.md)
+- [Camunda Cockpit](/charts/camunda-cockpit-keycloak/camunda-cockpit-keycloak/README.md)
+- [Operaton Cockpit](/charts/operaton-cockpit/operaton-cockpit/README.md)
 
 The generated list of published helm releases can be found [here](https://generiekzaakafhandelcomponent.github.io/helm-charts/index.yaml).
 

--- a/charts/operaton-cockpit/operaton-cockpit/.helmignore
+++ b/charts/operaton-cockpit/operaton-cockpit/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/operaton-cockpit/operaton-cockpit/Chart.yaml
+++ b/charts/operaton-cockpit/operaton-cockpit/Chart.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v2
+appVersion: v0.1.0
+description: |
+  A Helm chart for deploying the Operaton Cockpit Keycloak application.
+name: operaton-cockpit
+type: application
+version: 0.2.0

--- a/charts/operaton-cockpit/operaton-cockpit/LICENSE
+++ b/charts/operaton-cockpit/operaton-cockpit/LICENSE
@@ -1,0 +1,287 @@
+                      EUROPEAN UNION PUBLIC LICENCE v. 1.2
+                      EUPL © the European Union 2007, 2016
+
+This European Union Public Licence (the ‘EUPL’) applies to the Work (as defined
+below) which is provided under the terms of this Licence. Any use of the Work,
+other than as authorised under this Licence is prohibited (to the extent such
+use is covered by a right of the copyright holder of the Work).
+
+The Work is provided under the terms of this Licence when the Licensor (as
+defined below) has placed the following notice immediately following the
+copyright notice for the Work:
+
+        Licensed under the EUPL
+
+or has expressed by any other means his willingness to license under the EUPL.
+
+1. Definitions
+
+In this Licence, the following terms have the following meaning:
+
+- ‘The Licence’: this Licence.
+
+- ‘The Original Work’: the work or software distributed or communicated by the
+  Licensor under this Licence, available as Source Code and also as Executable
+  Code as the case may be.
+
+- ‘Derivative Works’: the works or software that could be created by the
+  Licensee, based upon the Original Work or modifications thereof. This Licence
+  does not define the extent of modification or dependence on the Original Work
+  required in order to classify a work as a Derivative Work; this extent is
+  determined by copyright law applicable in the country mentioned in Article 15.
+
+- ‘The Work’: the Original Work or its Derivative Works.
+
+- ‘The Source Code’: the human-readable form of the Work which is the most
+  convenient for people to study and modify.
+
+- ‘The Executable Code’: any code which has generally been compiled and which is
+  meant to be interpreted by a computer as a program.
+
+- ‘The Licensor’: the natural or legal person that distributes or communicates
+  the Work under the Licence.
+
+- ‘Contributor(s)’: any natural or legal person who modifies the Work under the
+  Licence, or otherwise contributes to the creation of a Derivative Work.
+
+- ‘The Licensee’ or ‘You’: any natural or legal person who makes any usage of
+  the Work under the terms of the Licence.
+
+- ‘Distribution’ or ‘Communication’: any act of selling, giving, lending,
+  renting, distributing, communicating, transmitting, or otherwise making
+  available, online or offline, copies of the Work or providing access to its
+  essential functionalities at the disposal of any other natural or legal
+  person.
+
+2. Scope of the rights granted by the Licence
+
+The Licensor hereby grants You a worldwide, royalty-free, non-exclusive,
+sublicensable licence to do the following, for the duration of copyright vested
+in the Original Work:
+
+- use the Work in any circumstance and for all usage,
+- reproduce the Work,
+- modify the Work, and make Derivative Works based upon the Work,
+- communicate to the public, including the right to make available or display
+  the Work or copies thereof to the public and perform publicly, as the case may
+  be, the Work,
+- distribute the Work or copies thereof,
+- lend and rent the Work or copies thereof,
+- sublicense rights in the Work or copies thereof.
+
+Those rights can be exercised on any media, supports and formats, whether now
+known or later invented, as far as the applicable law permits so.
+
+In the countries where moral rights apply, the Licensor waives his right to
+exercise his moral right to the extent allowed by law in order to make effective
+the licence of the economic rights here above listed.
+
+The Licensor grants to the Licensee royalty-free, non-exclusive usage rights to
+any patents held by the Licensor, to the extent necessary to make use of the
+rights granted on the Work under this Licence.
+
+3. Communication of the Source Code
+
+The Licensor may provide the Work either in its Source Code form, or as
+Executable Code. If the Work is provided as Executable Code, the Licensor
+provides in addition a machine-readable copy of the Source Code of the Work
+along with each copy of the Work that the Licensor distributes or indicates, in
+a notice following the copyright notice attached to the Work, a repository where
+the Source Code is easily and freely accessible for as long as the Licensor
+continues to distribute or communicate the Work.
+
+4. Limitations on copyright
+
+Nothing in this Licence is intended to deprive the Licensee of the benefits from
+any exception or limitation to the exclusive rights of the rights owners in the
+Work, of the exhaustion of those rights or of other applicable limitations
+thereto.
+
+5. Obligations of the Licensee
+
+The grant of the rights mentioned above is subject to some restrictions and
+obligations imposed on the Licensee. Those obligations are the following:
+
+Attribution right: The Licensee shall keep intact all copyright, patent or
+trademarks notices and all notices that refer to the Licence and to the
+disclaimer of warranties. The Licensee must include a copy of such notices and a
+copy of the Licence with every copy of the Work he/she distributes or
+communicates. The Licensee must cause any Derivative Work to carry prominent
+notices stating that the Work has been modified and the date of modification.
+
+Copyleft clause: If the Licensee distributes or communicates copies of the
+Original Works or Derivative Works, this Distribution or Communication will be
+done under the terms of this Licence or of a later version of this Licence
+unless the Original Work is expressly distributed only under this version of the
+Licence — for example by communicating ‘EUPL v. 1.2 only’. The Licensee
+(becoming Licensor) cannot offer or impose any additional terms or conditions on
+the Work or Derivative Work that alter or restrict the terms of the Licence.
+
+Compatibility clause: If the Licensee Distributes or Communicates Derivative
+Works or copies thereof based upon both the Work and another work licensed under
+a Compatible Licence, this Distribution or Communication can be done under the
+terms of this Compatible Licence. For the sake of this clause, ‘Compatible
+Licence’ refers to the licences listed in the appendix attached to this Licence.
+Should the Licensee's obligations under the Compatible Licence conflict with
+his/her obligations under this Licence, the obligations of the Compatible
+Licence shall prevail.
+
+Provision of Source Code: When distributing or communicating copies of the Work,
+the Licensee will provide a machine-readable copy of the Source Code or indicate
+a repository where this Source will be easily and freely available for as long
+as the Licensee continues to distribute or communicate the Work.
+
+Legal Protection: This Licence does not grant permission to use the trade names,
+trademarks, service marks, or names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the copyright notice.
+
+6. Chain of Authorship
+
+The original Licensor warrants that the copyright in the Original Work granted
+hereunder is owned by him/her or licensed to him/her and that he/she has the
+power and authority to grant the Licence.
+
+Each Contributor warrants that the copyright in the modifications he/she brings
+to the Work are owned by him/her or licensed to him/her and that he/she has the
+power and authority to grant the Licence.
+
+Each time You accept the Licence, the original Licensor and subsequent
+Contributors grant You a licence to their contributions to the Work, under the
+terms of this Licence.
+
+7. Disclaimer of Warranty
+
+The Work is a work in progress, which is continuously improved by numerous
+Contributors. It is not a finished work and may therefore contain defects or
+‘bugs’ inherent to this type of development.
+
+For the above reason, the Work is provided under the Licence on an ‘as is’ basis
+and without warranties of any kind concerning the Work, including without
+limitation merchantability, fitness for a particular purpose, absence of defects
+or errors, accuracy, non-infringement of intellectual property rights other than
+copyright as stated in Article 6 of this Licence.
+
+This disclaimer of warranty is an essential part of the Licence and a condition
+for the grant of any rights to the Work.
+
+8. Disclaimer of Liability
+
+Except in the cases of wilful misconduct or damages directly caused to natural
+persons, the Licensor will in no event be liable for any direct or indirect,
+material or moral, damages of any kind, arising out of the Licence or of the use
+of the Work, including without limitation, damages for loss of goodwill, work
+stoppage, computer failure or malfunction, loss of data or any commercial
+damage, even if the Licensor has been advised of the possibility of such damage.
+However, the Licensor will be liable under statutory product liability laws as
+far such laws apply to the Work.
+
+9. Additional agreements
+
+While distributing the Work, You may choose to conclude an additional agreement,
+defining obligations or services consistent with this Licence. However, if
+accepting obligations, You may act only on your own behalf and on your sole
+responsibility, not on behalf of the original Licensor or any other Contributor,
+and only if You agree to indemnify, defend, and hold each Contributor harmless
+for any liability incurred by, or claims asserted against such Contributor by
+the fact You have accepted any warranty or additional liability.
+
+10. Acceptance of the Licence
+
+The provisions of this Licence can be accepted by clicking on an icon ‘I agree’
+placed under the bottom of a window displaying the text of this Licence or by
+affirming consent in any other similar way, in accordance with the rules of
+applicable law. Clicking on that icon indicates your clear and irrevocable
+acceptance of this Licence and all of its terms and conditions.
+
+Similarly, you irrevocably accept this Licence and all of its terms and
+conditions by exercising any rights granted to You by Article 2 of this Licence,
+such as the use of the Work, the creation by You of a Derivative Work or the
+Distribution or Communication by You of the Work or copies thereof.
+
+11. Information to the public
+
+In case of any Distribution or Communication of the Work by means of electronic
+communication by You (for example, by offering to download the Work from a
+remote location) the distribution channel or media (for example, a website) must
+at least provide to the public the information requested by the applicable law
+regarding the Licensor, the Licence and the way it may be accessible, concluded,
+stored and reproduced by the Licensee.
+
+12. Termination of the Licence
+
+The Licence and the rights granted hereunder will terminate automatically upon
+any breach by the Licensee of the terms of the Licence.
+
+Such a termination will not terminate the licences of any person who has
+received the Work from the Licensee under the Licence, provided such persons
+remain in full compliance with the Licence.
+
+13. Miscellaneous
+
+Without prejudice of Article 9 above, the Licence represents the complete
+agreement between the Parties as to the Work.
+
+If any provision of the Licence is invalid or unenforceable under applicable
+law, this will not affect the validity or enforceability of the Licence as a
+whole. Such provision will be construed or reformed so as necessary to make it
+valid and enforceable.
+
+The European Commission may publish other linguistic versions or new versions of
+this Licence or updated versions of the Appendix, so far this is required and
+reasonable, without reducing the scope of the rights granted by the Licence. New
+versions of the Licence will be published with a unique version number.
+
+All linguistic versions of this Licence, approved by the European Commission,
+have identical value. Parties can take advantage of the linguistic version of
+their choice.
+
+14. Jurisdiction
+
+Without prejudice to specific agreement between parties,
+
+- any litigation resulting from the interpretation of this License, arising
+  between the European Union institutions, bodies, offices or agencies, as a
+  Licensor, and any Licensee, will be subject to the jurisdiction of the Court
+  of Justice of the European Union, as laid down in article 272 of the Treaty on
+  the Functioning of the European Union,
+
+- any litigation arising between other parties and resulting from the
+  interpretation of this License, will be subject to the exclusive jurisdiction
+  of the competent court where the Licensor resides or conducts its primary
+  business.
+
+15. Applicable Law
+
+Without prejudice to specific agreement between parties,
+
+- this Licence shall be governed by the law of the European Union Member State
+  where the Licensor has his seat, resides or has his registered office,
+
+- this licence shall be governed by Belgian law if the Licensor has no seat,
+  residence or registered office inside a European Union Member State.
+
+Appendix
+
+‘Compatible Licences’ according to Article 5 EUPL are:
+
+- GNU General Public License (GPL) v. 2, v. 3
+- GNU Affero General Public License (AGPL) v. 3
+- Open Software License (OSL) v. 2.1, v. 3.0
+- Eclipse Public License (EPL) v. 1.0
+- CeCILL v. 2.0, v. 2.1
+- Mozilla Public Licence (MPL) v. 2
+- GNU Lesser General Public Licence (LGPL) v. 2.1, v. 3
+- Creative Commons Attribution-ShareAlike v. 3.0 Unported (CC BY-SA 3.0) for
+  works other than software
+- European Union Public Licence (EUPL) v. 1.1, v. 1.2
+- Québec Free and Open-Source Licence — Reciprocity (LiLiQ-R) or Strong
+  Reciprocity (LiLiQ-R+).
+
+The European Commission may update this Appendix to later versions of the above
+licences without producing a new version of the EUPL, as long as they provide
+the rights granted in Article 2 of this Licence and protect the covered Source
+Code from exclusive appropriation.
+
+All other changes or additions to this Appendix require the production of a new
+EUPL version.

--- a/charts/operaton-cockpit/operaton-cockpit/README.md
+++ b/charts/operaton-cockpit/operaton-cockpit/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
 
-A Helm chart for deploying the Operaton Cockpit application.
+A Helm chart for deploying the Operaton Cockpit Keycloak application.
 
 ## Values
 
@@ -47,12 +47,6 @@ A Helm chart for deploying the Operaton Cockpit application.
 | serviceAccount.automountServiceAccountToken | bool | `false` | Whether or not the service account token should be mounted into the pod.  Mounting is only required when Kubernetes API access is needed. |
 | serviceAccount.create | bool | `true` | By default, the service account is created to avoid security risks when using the 'default' Kubernetes service account. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| settings.operaton.authorization.enabled | bool | `true` |  |
-| settings.operaton.database.type | string | `"postgres"` |  |
-| settings.operaton.historyLevel | string | `"audit"` |  |
-| settings.operaton.jobExecution.deploymentAware | bool | `true` |  |
-| settings.operaton.jobExecution.enabled | bool | `false` |  |
-| settings.operaton.webapp.applicationPath | string | `nil` |  |
 | settings.logLevelSpringSecurity | string | `"DEBUG"` |  |
 | settings.management.endpoint.health.showDetails | string | `"when_authorized"` |  |
 | settings.management.endpoints.jmx.exposure.exclude | string | `"*"` |  |
@@ -63,6 +57,12 @@ A Helm chart for deploying the Operaton Cockpit application.
 | settings.management.info.env.enabled | bool | `true` |  |
 | settings.management.info.git.enabled | bool | `true` |  |
 | settings.management.info.git.mode | string | `"simple"` |  |
+| settings.operaton.authorization.enabled | bool | `true` |  |
+| settings.operaton.database.type | string | `"postgres"` |  |
+| settings.operaton.historyLevel | string | `"audit"` |  |
+| settings.operaton.jobExecution.deploymentAware | bool | `true` |  |
+| settings.operaton.jobExecution.enabled | bool | `false` |  |
+| settings.operaton.webapp.applicationPath | string | `nil` |  |
 | settings.plugin.administratorGroupName | string | `"operaton-admin"` |  |
 | settings.plugin.disableSSLCertificateValidation | bool | `true` |  |
 | settings.plugin.enforceSubgroupsInGroupQuery | bool | `true` |  |

--- a/charts/operaton-cockpit/operaton-cockpit/README.md
+++ b/charts/operaton-cockpit/operaton-cockpit/README.md
@@ -1,0 +1,93 @@
+# operaton-cockpit
+
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+
+A Helm chart for deploying the Operaton Cockpit application.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling | object | `{"enabled":false,"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | Enabling autoscaling will automatically render the `replicaCount` value unused. |
+| existingSecret | string | `nil` | Provide the name of a Secret containing the same keys as  the keys as the Secret in 'secret.yaml' in this chart. |
+| fullnameOverride | string | `""` | To override the name used primarily as name for the resources. |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"ghcr.io/ritense/operaton-cockpit"` |  |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` | A list that references secrets in the same namespace. |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` | Set the ingress class name, unless the default class is sufficient. |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| ingress.tls | list | `[]` |  |
+| livenessProbe.failureThreshold | int | `6` |  |
+| livenessProbe.initialDelaySeconds | int | `40` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `1` |  |
+| nameOverride | string | `""` | To override the name of the chart deployed. |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext | object | `{"fsGroup":1000,"runAsGroup":1000,"runAsUser":1000}` | An intentional strict default pod context. Adjust accordingly or configure  container specific settings using the 'securityContext' value. |
+| readinessProbe.failureThreshold | int | `6` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `20` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `1` |  |
+| replicaCount | int | `1` | Number of replicas, only in use if autoscaling is disabled. |
+| resources.limits | object | `{"cpu":"250m","memory":"512Mi"}` | Limits are set to avoid resource based denial of service by default, adjust accordingly. |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | An intentional strict default container context. Adjust accordingly. |
+| service.port | int | `80` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Whether or not the service account token should be mounted into the pod.  Mounting is only required when Kubernetes API access is needed. |
+| serviceAccount.create | bool | `true` | By default, the service account is created to avoid security risks when using the 'default' Kubernetes service account. |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| settings.operaton.authorization.enabled | bool | `true` |  |
+| settings.operaton.database.type | string | `"postgres"` |  |
+| settings.operaton.historyLevel | string | `"audit"` |  |
+| settings.operaton.jobExecution.deploymentAware | bool | `true` |  |
+| settings.operaton.jobExecution.enabled | bool | `false` |  |
+| settings.operaton.webapp.applicationPath | string | `nil` |  |
+| settings.logLevelSpringSecurity | string | `"DEBUG"` |  |
+| settings.management.endpoint.health.showDetails | string | `"when_authorized"` |  |
+| settings.management.endpoints.jmx.exposure.exclude | string | `"*"` |  |
+| settings.management.endpoints.web.basePath | string | `"/management"` |  |
+| settings.management.endpoints.web.exposure.include[0] | string | `"health"` |  |
+| settings.management.endpoints.web.exposure.include[1] | string | `"info"` |  |
+| settings.management.info.build.enabled | bool | `true` |  |
+| settings.management.info.env.enabled | bool | `true` |  |
+| settings.management.info.git.enabled | bool | `true` |  |
+| settings.management.info.git.mode | string | `"simple"` |  |
+| settings.plugin.administratorGroupName | string | `"operaton-admin"` |  |
+| settings.plugin.disableSSLCertificateValidation | bool | `true` |  |
+| settings.plugin.enforceSubgroupsInGroupQuery | bool | `true` |  |
+| settings.plugin.keycloakAdminUrl | string | `nil` |  |
+| settings.plugin.useEmailAsOperatonUserId | bool | `false` |  |
+| settings.plugin.useGroupPathAsOperatonGroupId | bool | `true` |  |
+| settings.plugin.useUsernameAsOperatonUserId | bool | `true` |  |
+| settings.server.port | int | `8084` |  |
+| settings.server.servlet.contextPath | string | `"/"` |  |
+| settings.spring.application.name | string | `"operaton-cockpit"` |  |
+| settings.spring.datasource.driverClassName | string | `"org.postgresql.Driver"` |  |
+| settings.spring.datasource.password | string | `nil` |  |
+| settings.spring.datasource.url | string | `nil` |  |
+| settings.spring.datasource.username | string | `nil` |  |
+| settings.spring.keycloak.authorizationGrantType | string | `"authorization_code"` |  |
+| settings.spring.keycloak.clientId | string | `"operaton-identity-service"` |  |
+| settings.spring.keycloak.clientSecret | string | `nil` |  |
+| settings.spring.keycloak.provider | string | `"keycloak"` |  |
+| settings.spring.keycloak.providerIssuerUri | string | `""` |  |
+| settings.spring.keycloak.providerUserNameAttribute | string | `"preferred_username"` |  |
+| settings.spring.keycloak.redirectUri | string | `"/login/oauth2/code/keycloak"` |  |
+| settings.spring.keycloak.scope | string | `"openid, profile, email"` |  |
+| startupProbe.failureThreshold | int | `30` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| tolerations | list | `[]` |  |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/operaton-cockpit/operaton-cockpit/templates/NOTES.txt
+++ b/charts/operaton-cockpit/operaton-cockpit/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "operaton-cockpit.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "operaton-cockpit.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "operaton-cockpit.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "operaton-cockpit.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/operaton-cockpit/operaton-cockpit/templates/_helpers.tpl
+++ b/charts/operaton-cockpit/operaton-cockpit/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "operaton-cockpit.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "operaton-cockpit.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "operaton-cockpit.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "operaton-cockpit.labels" -}}
+helm.sh/chart: {{ include "operaton-cockpit.chart" . }}
+{{ include "operaton-cockpit.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "operaton-cockpit.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "operaton-cockpit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "operaton-cockpit.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "operaton-cockpit.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/operaton-cockpit/operaton-cockpit/templates/configmap.yaml
+++ b/charts/operaton-cockpit/operaton-cockpit/templates/configmap.yaml
@@ -1,0 +1,71 @@
+---
+# The keys of the ConfigMap will be environment variables for the pod.
+# In line with Spring Boot's relaxed binding, settings from the 
+# 'application.yml' file is transformed using the following steps:
+#   1. Replace dots (.) with underscores (_).
+#   2. Remove any dashes (-).
+#   3. Convert to uppercase.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "operaton-cockpit.fullname" . }}
+  labels:
+    {{- include "operaton-cockpit.labels" . | nindent 4 }}
+data:
+  SERVER_PORT: {{ .Values.settings.server.port | quote }}
+  SERVER_SERVLET_CONTEXTPATH: {{ .Values.settings.server.servlet.contextPath | quote }}
+  {{- with .Values.settings.spring }}
+  SPRING_APPLICATION_NAME: {{ .application.name | quote }}
+  SPRING_DATASOURCE_DRIVERCLASSNAME: {{ .datasource.driverClassName | quote }}
+  SPRING_DATASOURCE_URL: {{ .datasource.url | quote }}
+  SPRING_DATASOURCE_USERNAME: {{ .datasource.username | quote }}
+  {{- end }}
+  {{- with .Values.settings.operaton }}
+  OPERATON_BPM_HISTORYLEVEL: {{ .historyLevel | quote }}
+  OPERATON_BPM_AUTHORIZATION_ENABLED: {{ .authorization.enabled | quote }}
+  OPERATON_BPM_DATABASE_TYPE: {{ .database.type | quote }}
+  OPERATON_BPM_WEBAPP_APPLICATIONPATH: {{ .webapp.applicationPath | quote }}
+  OPERATON_BPM_JOBEXECUTION_ENABLED: {{ .jobExecution.enabled | quote }}
+  OPERATON_BPM_JOBEXECUTION_DEPLOYMENTAWARE: {{ .jobExecution.deploymentAware | quote }}
+  {{- end }}
+  {{- with .Values.settings.plugin }}
+  PLUGIN_IDENTITY_KEYCLOAK_KEYCLOAKADMINURL: {{ .keycloakAdminUrl | quote }}
+  PLUGIN_IDENTITY_KEYCLOAK_USEEMAILASOPERATONUSERID: {{ .useEmailAsOperatonUserId | quote }}
+  PLUGIN_IDENTITY_KEYCLOAK_ADMINISTRATORGROUPNAME: {{ .administratorGroupName | quote }}
+  PLUGIN_IDENTITY_KEYCLOAK_USEUSERNAMEASOPERATONUSERID: {{ .useUsernameAsOperatonUserId | quote }}
+  PLUGIN_IDENTITY_KEYCLOAK_DISABLESSLCERTIFICATEVALIDATION: {{ .disableSSLCertificateValidation | quote }}
+  PLUGIN_IDENTITY_KEYCLOAK_USEGROUPPATHASOPERATONGROUPID: {{ .useGroupPathAsOperatonGroupId | quote }}
+  PLUGIN_IDENTITY_KEYCLOAK_ENFORCESUBGROUPSINGROUPQUERY: {{ .enforceSubgroupsInGroupQuery | quote }}
+  {{- end }}
+  {{- with .Values.settings.spring.keycloak }}
+  PLUGIN_IDENTITY_KEYCLOAK_KEYCLOAKISSUERURL: {{ .providerIssuerUri | quote }}
+  PLUGIN_IDENTITY_KEYCLOAK_CLIENTID: {{ .clientId | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_PROVIDER: {{ .provider | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTID: {{ .clientId | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_AUTHORIZATIONGRANTTYPE: {{ .authorizationGrantType | quote }}
+  {{- $redirectHost := "" -}}
+  {{- with $.Values.ingress }}
+    {{- if gt (len .hosts) 0 }}
+      {{- $redirectHost = printf "%v" (index (index .hosts 0) "host") -}}
+    {{- end }}
+  {{- end }}
+  SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_REDIRECTURI: {{ printf "https://%s%s" $redirectHost .redirectUri | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_SCOPE: {{ .scope | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUERURI: {{ .providerIssuerUri | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_AUTHORIZATIONURI: {{ print .providerIssuerUri "/protocol/openid-connect/auth" | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_USERINFOURI: {{ print .providerIssuerUri "/protocol/openid-connect/userinfo" | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_TOKENURI: {{ print .providerIssuerUri "/protocol/openid-connect/token" | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_JWKSETURI: {{ print .providerIssuerUri "/protocol/openid-connect/certs" | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_USERNAMEATTRIBUTE: {{ .providerUserNameAttribute | quote }}
+  {{- end }}
+  {{- with .Values.settings.management }}
+  MANAGEMENT_ENDPOINTS_WEB_BASEPATH: {{ .endpoints.web.basePath | quote }}
+  MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: {{ .endpoints.web.exposure.include | join "," | quote }}
+  MANAGEMENT_ENDPOINTS_JMX_EXPOSURE_EXCLUDE: {{ .endpoints.jmx.exposure.exclude | quote }}
+  MANAGEMENT_ENDPOINT_HEALTH_SHOWDETAILS: {{ .endpoint.health.showDetails | quote }}
+  MANAGEMENT_INFO_GIT_MODE: {{ .info.git.mode | quote }}
+  MANAGEMENT_INFO_GIT_ENABLED: {{ .info.git.enabled | quote }}
+  MANAGEMENT_INFO_BUILD_ENABLED: {{ .info.build.enabled | quote }}
+  MANAGEMENT_INFO_ENV_ENABLED: {{ .info.env.enabled | quote }}
+  {{- end }}
+  LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_SECURITY: {{ .Values.settings.logLevelSpringSecurity | quote }}

--- a/charts/operaton-cockpit/operaton-cockpit/templates/deployment.yaml
+++ b/charts/operaton-cockpit/operaton-cockpit/templates/deployment.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "operaton-cockpit.fullname" . }}
+  labels:
+    {{- include "operaton-cockpit.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "operaton-cockpit.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "operaton-cockpit.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "operaton-cockpit.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.existingSecret | default (include "operaton-cockpit.fullname" .) }}
+            - configMapRef:
+                name: {{ include "operaton-cockpit.fullname" . }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.settings.server.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /management/health
+              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /management/health
+              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /management/health
+              port: http
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/operaton-cockpit/operaton-cockpit/templates/hpa.yaml
+++ b/charts/operaton-cockpit/operaton-cockpit/templates/hpa.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "operaton-cockpit.fullname" . }}
+  labels:
+    {{- include "operaton-cockpit.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "operaton-cockpit.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/operaton-cockpit/operaton-cockpit/templates/ingress.yaml
+++ b/charts/operaton-cockpit/operaton-cockpit/templates/ingress.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.ingress.enabled -}}
+---
+{{- $fullName := include "operaton-cockpit.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "operaton-cockpit.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if .pathType }}
+            pathType: {{ .pathType }}
+            {{- else }}
+            pathType: ImplementationSpecific
+            {{- end }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/operaton-cockpit/operaton-cockpit/templates/secret.yaml
+++ b/charts/operaton-cockpit/operaton-cockpit/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.existingSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "operaton-cockpit.fullname" . }}
+  labels:
+    {{- include "operaton-cockpit.labels" . | nindent 4 }}
+type: Opaque
+data:
+  SPRING_DATASOURCE_PASSWORD: {{ .Values.settings.spring.datasource.password | toString | b64enc | quote }}
+  PLUGIN_IDENTITY_KEYCLOAK_CLIENTSECRET: {{ .Values.settings.spring.keycloak.clientSecret | toString | b64enc | quote }}
+  SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENTSECRET: {{ .Values.settings.spring.keycloak.clientSecret | toString | b64enc | quote }}
+{{- end }}

--- a/charts/operaton-cockpit/operaton-cockpit/templates/service.yaml
+++ b/charts/operaton-cockpit/operaton-cockpit/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "operaton-cockpit.fullname" . }}
+  labels:
+    {{- include "operaton-cockpit.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "operaton-cockpit.selectorLabels" . | nindent 4 }}

--- a/charts/operaton-cockpit/operaton-cockpit/templates/serviceaccount.yaml
+++ b/charts/operaton-cockpit/operaton-cockpit/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "operaton-cockpit.serviceAccountName" . }}
+  labels:
+    {{- include "operaton-cockpit.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/operaton-cockpit/operaton-cockpit/templates/tests/test-connection.yaml
+++ b/charts/operaton-cockpit/operaton-cockpit/templates/tests/test-connection.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "operaton-cockpit.fullname" . }}-test-connection"
+  labels:
+    {{- include "operaton-cockpit.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "operaton-cockpit.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/operaton-cockpit/operaton-cockpit/test.values.yaml
+++ b/charts/operaton-cockpit/operaton-cockpit/test.values.yaml
@@ -1,0 +1,15 @@
+---
+image:
+  tag: main-202508061324-bbf8a692
+
+settings:
+  spring:
+    datasource:
+      url: https://url.postgres.test
+      username: postgres
+      password: postgres
+    keycloak:
+      clientSecret: test
+
+  plugin:
+    keycloakAdminUrl: http://localhost/auth/admin/realms/test

--- a/charts/operaton-cockpit/operaton-cockpit/values.yaml
+++ b/charts/operaton-cockpit/operaton-cockpit/values.yaml
@@ -1,0 +1,193 @@
+---
+# Default values for operaton-cockpit.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Number of replicas, only in use if autoscaling is disabled.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/ritense/operaton-cockpit
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# -- A list that references secrets in the same namespace.
+imagePullSecrets: []
+# -- To override the name of the chart deployed.
+nameOverride: ""
+# -- To override the name used primarily as name for the resources.
+fullnameOverride: ""
+
+serviceAccount:
+  # -- By default, the service account is created to avoid security risks when using the 'default' Kubernetes service account.
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # -- Whether or not the service account token should be mounted into the pod. 
+  # Mounting is only required when Kubernetes API access is needed.
+  automountServiceAccountToken: false
+
+podAnnotations: {}
+
+podLabels: {}
+
+# -- An intentional strict default pod context. Adjust accordingly or configure 
+# container specific settings using the 'securityContext' value.
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+# -- An intentional strict default container context. Adjust accordingly.
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  # -- Set the ingress class name, unless the default class is sufficient.
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+livenessProbe:
+  initialDelaySeconds: 40
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 6
+  successThreshold: 1
+
+readinessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 20
+  timeoutSeconds: 1
+  failureThreshold: 6
+  successThreshold: 1
+
+startupProbe:
+  failureThreshold: 30
+  periodSeconds: 10
+
+
+resources:
+  # -- Limits are set to avoid resource based denial of service by default, adjust accordingly.
+  limits:
+   cpu: 250m
+   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# -- Enabling autoscaling will automatically render the `replicaCount` value unused.
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  #targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# -- Provide the name of a Secret containing the same keys as 
+# the keys as the Secret in 'secret.yaml' in this chart.
+existingSecret: null
+
+settings:
+  server:
+    port: 8084
+    servlet:
+      contextPath: /
+
+  spring:
+    application:
+      name: operaton-cockpit
+    datasource:
+      driverClassName: org.postgresql.Driver
+      url:
+      username:
+      password:
+    keycloak:
+      provider: keycloak
+      clientId: operaton-identity-service
+      clientSecret:
+      authorizationGrantType: authorization_code
+      redirectUri: /login/oauth2/code/keycloak
+      scope: openid, profile, email
+      providerIssuerUri: ""
+      # set user-name-attribute one of:
+      # - sub                -> default; using keycloak ID as operaton user ID
+      # - email              -> useEmailAsOperatonUserId=true
+      # - preferred_username -> useUsernameAsOperatonUserId=true
+      providerUserNameAttribute: preferred_username 
+
+  operaton:
+    historyLevel: audit
+    authorization:
+      enabled: true
+    database:
+      type: postgres
+    webapp:
+      applicationPath:
+    jobExecution:
+      enabled: false
+      deploymentAware: true
+
+  plugin:
+    keycloakAdminUrl:
+    useEmailAsOperatonUserId: false
+    administratorGroupName: operaton-admin
+    useUsernameAsOperatonUserId: true
+    disableSSLCertificateValidation: true
+    useGroupPathAsOperatonGroupId: true
+    enforceSubgroupsInGroupQuery: true
+
+  logLevelSpringSecurity: DEBUG
+
+  management:
+    endpoints:
+      web:
+        basePath: /management
+        exposure:
+          include: 
+          - "health"
+          - "info"
+      jmx:
+        exposure:
+          exclude: "*"
+    endpoint:
+      health:
+        showDetails: when_authorized
+    info:
+      git:
+        mode: simple
+        enabled: true
+      build:
+        enabled: true
+      env:
+        enabled: true


### PR DESCRIPTION
**Why**
- Camunda-cockpit-keycloak is deprecated: https://github.com/ritense/camunda-cockpit-keycloak
- Replacement lives here: https://github.com/ritense/operaton-cockpit

**What**
- In this PR I duplicated the existing `camunda-cockpit-keycloak` and renamed it to `operaton-cockpit`. 
- I did not make any other changes besides renaming things.

**TODO**
- Add [ghcr.io/ritense/operaton-cockpit](https://github.com/ritense/operaton-cockpit/pkgs/container/operaton-cockpit) (I don't have the rights)